### PR TITLE
docs(skill): clarify back-merge PR does not require code review (#5)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -255,7 +255,8 @@ The initial setup is the **only** allowed direct commit to `main`. This is a one
    git push origin v1.2.0
 
 6. PR: main → develop (back-merge)
-   - Ensures develop has the version bump and changelog
+   - No code review required (content already reviewed for main)
+   - Exists for CI validation and audit trail only
    - Merge with --no-ff
 
 7. Delete release branch (remote + local)
@@ -279,7 +280,8 @@ The initial setup is the **only** allowed direct commit to `main`. This is a one
    - Merge with --no-ff, tag v1.2.1
 
 6. PR: main → develop (back-merge)
-   - Ensures develop gets the fix
+   - No code review required (content already reviewed for main)
+   - Exists for CI validation and audit trail only
    - Merge with --no-ff
 
 7. Delete hotfix branch (remote + local)


### PR DESCRIPTION
## Summary

- Clarify in both release and hotfix processes that the back-merge PR (main → develop) does not require code review approval
- The content was already reviewed when merged into main; the PR exists for CI validation and audit trail only

Closes #5

## Test plan

- [x] Verify release process back-merge step mentions no review required
- [x] Verify hotfix process back-merge step mentions no review required