### PR TITLE
chore: back-merge main after v1.0.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.1] - 2026-03-18
+
+### Changed
+
+- Clarify back-merge PR (main → develop) does not require code review (#5)
+
 ## [1.0.0] - 2026-03-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Git Workflow — Claude Code Skill
 
-[![Version](https://img.shields.io/badge/version-1.0.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.0.1-blue.svg)](CHANGELOG.md)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-skill-7c3aed.svg)](https://claude.ai/code)
 [![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196.svg?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: git-workflow
 description: "Enforce a strict Gitflow-based workflow with conventional commits, semantic versioning, and issue-driven branching. Use when the user asks to commit, create a branch, open a PR, tag a release, or perform any git operation. Also applies when mentions 'commit', 'branch', 'merge', 'release', 'hotfix', 'gitflow', 'conventional commit', 'semantic versioning', or 'semver'."
-version: 1.0.0
+version: 1.0.1
 license: MIT
 metadata:
   author: Qubernetic
@@ -255,7 +255,8 @@ The initial setup is the **only** allowed direct commit to `main`. This is a one
    git push origin v1.2.0
 
 6. PR: main → develop (back-merge)
-   - Ensures develop has the version bump and changelog
+   - No code review required (content already reviewed for main)
+   - Exists for CI validation and audit trail only
    - Merge with --no-ff
 
 7. Delete release branch (remote + local)
@@ -279,7 +280,8 @@ The initial setup is the **only** allowed direct commit to `main`. This is a one
    - Merge with --no-ff, tag v1.2.1
 
 6. PR: main → develop (back-merge)
-   - Ensures develop gets the fix
+   - No code review required (content already reviewed for main)
+   - Exists for CI validation and audit trail only
    - Merge with --no-ff
 
 7. Delete hotfix branch (remote + local)


### PR DESCRIPTION
Back-merge after v1.0.1 release. No code review required — content already reviewed for main.