### PR TITLE
fix: correct back-merge direction in branch model diagram (#10)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ gitGraph
     merge "release/1.0" id: "  " tag: "v1.0.0"
 
     checkout develop
-    merge "release/1.0" id: " back-merge"
+    merge main id: " back-merge"
 
     checkout main
     branch "hotfix/4-crash" order: 2
@@ -108,7 +108,7 @@ gitGraph
     merge "hotfix/4-crash" id: "   " tag: "v1.0.1"
 
     checkout develop
-    merge "hotfix/4-crash" id: " hotfix-sync"
+    merge main id: " hotfix-sync"
 
     commit id: "next"
 ```


### PR DESCRIPTION
## Summary

- Fix back-merge arrows in Mermaid gitgraph: now correctly flow from `main` → `develop` instead of from release/hotfix branches directly into develop
- This makes `main` and `develop` visibly connected in the diagram

Closes #10

## Test plan

- [x] Verify Mermaid diagram renders correctly on GitHub
- [x] Verify back-merge lines connect main to develop