### PR TITLE
chore: back-merge main after v1.0.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.2] - 2026-03-18
+
+### Fixed
+
+- Correct back-merge direction in branch model diagram: now flows from main → develop (#10)
+
 ## [1.0.1] - 2026-03-18
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Git Workflow — Claude Code Skill
 
-[![Version](https://img.shields.io/badge/version-1.0.1-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.0.2-blue.svg)](CHANGELOG.md)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-skill-7c3aed.svg)](https://claude.ai/code)
 [![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196.svg?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
@@ -97,7 +97,7 @@ gitGraph
     merge "release/1.0" id: "  " tag: "v1.0.0"
 
     checkout develop
-    merge "release/1.0" id: " back-merge"
+    merge main id: " back-merge"
 
     checkout main
     branch "hotfix/4-crash" order: 2
@@ -108,7 +108,7 @@ gitGraph
     merge "hotfix/4-crash" id: "   " tag: "v1.0.1"
 
     checkout develop
-    merge "hotfix/4-crash" id: " hotfix-sync"
+    merge main id: " hotfix-sync"
 
     commit id: "next"
 ```

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: git-workflow
 description: "Enforce a strict Gitflow-based workflow with conventional commits, semantic versioning, and issue-driven branching. Use when the user asks to commit, create a branch, open a PR, tag a release, or perform any git operation. Also applies when mentions 'commit', 'branch', 'merge', 'release', 'hotfix', 'gitflow', 'conventional commit', 'semantic versioning', or 'semver'."
-version: 1.0.1
+version: 1.0.2
 license: MIT
 metadata:
   author: Qubernetic


### PR DESCRIPTION
Back-merge after v1.0.2 release. No code review required — content already reviewed for main.