### PR TITLE
fix: add missing metadata.version field to SKILL.md frontmatter (#15)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -5,6 +5,7 @@ version: 1.0.2
 license: MIT
 metadata:
   author: Qubernetic
+  version: 1.0.2
 ---
 
 # Git Workflow Skill


### PR DESCRIPTION
## Summary
- Add `metadata.version: 1.0.2` to SKILL.md frontmatter to satisfy the version sync requirement documented in CLAUDE.md

## Test plan
- [x] Verify SKILL.md frontmatter contains `metadata.version: 1.0.2`
- [x] Verify value matches `version` field and CHANGELOG.md

Closes #15