### PR TITLE
docs: add comparison links to CHANGELOG.md (#16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,3 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLAUDE.md project guidance
 - CONTRIBUTING.md contribution guidelines
 - GitHub issue and PR templates
+
+[1.0.2]: https://github.com/qubernetic-org/git-workflow-agent-skill/compare/v1.0.1...v1.0.2
+[1.0.1]: https://github.com/qubernetic-org/git-workflow-agent-skill/compare/v1.0.0...v1.0.1
+[1.0.0]: https://github.com/qubernetic-org/git-workflow-agent-skill/releases/tag/v1.0.0


### PR DESCRIPTION
## Summary
- Add Keep a Changelog version comparison links at the bottom of CHANGELOG.md for all existing versions (1.0.0, 1.0.1, 1.0.2)

## Test plan
- [x] Verify links point to correct GitHub compare/release URLs
- [x] Verify all CHANGELOG versions have a corresponding link

Closes #16