### PR TITLE
docs: clarify GitHub merge strategy for --no-ff requirement (#17)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -59,6 +59,8 @@ Enforce a disciplined Gitflow-based development workflow. Every git operation fo
 - **Never squash merge** into protected branches — squashing destroys the atomic commit history you carefully crafted
 - **Never rebase merge** into protected branches — rebase rewrites hashes and removes merge commit markers
 
+> **GitHub settings:** In repository settings, only enable "Allow merge commits" and disable "Allow squash merging" and "Allow rebase merging". When using `gh pr merge`, always pass `--merge --delete-branch`.
+
 ### Keeping Feature Branches Up to Date
 
 - **Not yet pushed**: rebase onto `develop` is acceptable (`git rebase develop`)


### PR DESCRIPTION
## Summary
- Add guidance on GitHub repository settings and `gh pr merge` flags to enforce the --no-ff merge requirement

## Test plan
- [x] Verify the note appears in the Merge Strategy section of SKILL.md
- [x] Verify it correctly maps GitHub options to the skill's merge rules

Closes #17