### PR TITLE
docs: clarify semver impact for revert commit type (#18)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -101,7 +101,9 @@ Enforce a disciplined Gitflow-based development workflow. Every git operation fo
 | `perf` | Performance improvement | PATCH bump |
 | `ci` | CI/CD configuration changes | None |
 | `build` | Build system or external dependency changes | None |
-| `revert` | Reverting a previous commit | Depends |
+| `revert` | Reverting a previous commit | Depends on the original commit type |
+
+> **Revert semver note:** The impact mirrors the reverted commit's type. Reverting a `feat` removes a capability (potentially MAJOR if it was public API), reverting a `fix` reintroduces a bug (PATCH when re-fixed). Evaluate the user-facing effect at release time.
 
 ### Breaking Changes
 


### PR DESCRIPTION
## Summary
- Expand the `revert` row in the commit types table to clarify that semver impact depends on the original commit type
- Add a blockquote note explaining how to evaluate revert impact at release time

## Test plan
- [x] Verify the types table shows "Depends on the original commit type" for `revert`
- [x] Verify the clarifying note appears between the types table and Breaking Changes section

Closes #18