### PR TITLE
docs: emphasize workflow discipline independent of branch protection (#25)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -32,6 +32,7 @@ Enforce a disciplined Gitflow-based development workflow. Every git operation fo
 5. **Issue-driven workflow** — every branch starts from a GitHub Issue and closes it
 6. **PR-only merges** — `main` and `develop` are never committed to directly
 7. **Always `--no-ff`** — all merges into protected branches use `--no-ff` to preserve branch topology
+8. **Discipline over tooling** — follow all workflow rules even when branch protection is not configured or when operating as an admin user who can bypass it. Branch protection is a safety net, not a substitute for discipline. Early-stage repositories may lack protection rules, and admin users are often exempt — neither case permits direct commits to protected branches or merging without a PR.
 
 ---
 


### PR DESCRIPTION
## Summary
- Add 8th core principle: "Discipline over tooling" — workflow rules apply regardless of branch protection status
- Explicitly calls out early-stage repos without protection and admin bypass as scenarios where discipline must still hold

## Test plan
- [x] Verify new principle #8 appears in Core Principles section
- [x] Verify it covers both early-stage repos and admin bypass scenarios

Closes #25