### PR TITLE
chore(release): prepare 1.0.3 (#27)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,20 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2026-03-18
+
+### Fixed
+
+- Add missing metadata.version field to SKILL.md frontmatter (#15)
+
+### Changed
+
+- Clarify GitHub merge strategy for --no-ff requirement (#17)
+- Clarify semver impact for revert commit type (#18)
+- Document GitHub auto-close limitation with non-default branch merges (#23)
+- Emphasize workflow discipline independent of branch protection (#25)
+- Add comparison links to CHANGELOG.md (#16)
+
 ## [1.0.2] - 2026-03-18
 
 ### Fixed
@@ -39,6 +53,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CONTRIBUTING.md contribution guidelines
 - GitHub issue and PR templates
 
+[1.0.3]: https://github.com/qubernetic-org/git-workflow-agent-skill/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/qubernetic-org/git-workflow-agent-skill/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/qubernetic-org/git-workflow-agent-skill/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/qubernetic-org/git-workflow-agent-skill/releases/tag/v1.0.0

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: git-workflow
 description: "Enforce a strict Gitflow-based workflow with conventional commits, semantic versioning, and issue-driven branching. Use when the user asks to commit, create a branch, open a PR, tag a release, or perform any git operation. Also applies when mentions 'commit', 'branch', 'merge', 'release', 'hotfix', 'gitflow', 'conventional commit', 'semantic versioning', or 'semver'."
-version: 1.0.2
+version: 1.0.3
 license: MIT
 metadata:
   author: Qubernetic
-  version: 1.0.2
+  version: 1.0.3
 ---
 
 # Git Workflow Skill


### PR DESCRIPTION
## Summary
- Bump version to 1.0.3 in SKILL.md frontmatter and metadata
- Update CHANGELOG.md with all changes since v1.0.2

### Changes in this release

#### Fixed
- Add missing metadata.version field to SKILL.md frontmatter (#15)

#### Changed
- Clarify GitHub merge strategy for --no-ff requirement (#17)
- Clarify semver impact for revert commit type (#18)
- Document GitHub auto-close limitation with non-default branch merges (#23)
- Emphasize workflow discipline independent of branch protection (#25)
- Add comparison links to CHANGELOG.md (#16)

Closes #27