### PR TITLE
chore(release): prepare 1.0.4 (#32)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.4] - 2026-03-18
+
+### Changed
+
+- Add GitHub Release template and creation step to release process (#30)
+
 ## [1.0.3] - 2026-03-18
 
 ### Fixed
@@ -53,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CONTRIBUTING.md contribution guidelines
 - GitHub issue and PR templates
 
+[1.0.4]: https://github.com/qubernetic-org/git-workflow-agent-skill/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/qubernetic-org/git-workflow-agent-skill/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/qubernetic-org/git-workflow-agent-skill/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/qubernetic-org/git-workflow-agent-skill/compare/v1.0.0...v1.0.1

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: git-workflow
 description: "Enforce a strict Gitflow-based workflow with conventional commits, semantic versioning, and issue-driven branching. Use when the user asks to commit, create a branch, open a PR, tag a release, or perform any git operation. Also applies when mentions 'commit', 'branch', 'merge', 'release', 'hotfix', 'gitflow', 'conventional commit', 'semantic versioning', or 'semver'."
-version: 1.0.3
+version: 1.0.4
 license: MIT
 metadata:
   author: Qubernetic
-  version: 1.0.3
+  version: 1.0.4
 ---
 
 # Git Workflow Skill


### PR DESCRIPTION
## Summary
- Bump version to 1.0.4 in SKILL.md frontmatter and metadata
- Update CHANGELOG.md with changes since v1.0.3

### Changes in this release

#### Changed
- Add GitHub Release template and creation step to release process (#30)

Closes #32