### PR TITLE
fix: add missing commit types to Decision Guide (#38)

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -507,6 +507,10 @@ Follow [Keep a Changelog](https://keepachangelog.com/):
 | Restructured code without behavior change | `refactor` |
 | Added or updated tests | `test` |
 | Improved performance | `perf` |
+| Formatting, whitespace (no logic change) | `style` |
+| CI/CD pipeline changes | `ci` |
+| Build system or dependency changes | `build` |
+| Reverting a previous commit | `revert` |
 
 ### "Do I bump the version?"
 


### PR DESCRIPTION
## Summary
- Add `style`, `ci`, `build`, and `revert` to the Decision Guide commit type table
- Now matches the full Types table in Commit Message Format section

Closes #38

## Test plan
- [x] Verify all 11 types from the Types table appear in the Decision Guide