### PR TITLE
chore(release): prepare 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,22 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2026-03-27
+
+### Added
+
+- Automated linting script for SKILL.md structure validation (#57)
+- Troubleshooting section with recovery steps for 5 common workflow mistakes (#58)
+- ONBOARDING.md for new contributors (#59)
+
+### Changed
+
+- Improve CONTRIBUTING.md with development workflow and cross-platform lint guide (#63)
+
+### Fixed
+
+- Lint script: skip code block contents in heading hierarchy check (#58)
+
 ## [1.1.0] - 2026-03-27
 
 ### Added
@@ -77,6 +93,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CONTRIBUTING.md contribution guidelines
 - GitHub issue and PR templates
 
+[1.2.0]: https://github.com/qubernetic-org/git-workflow-agent-skill/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/qubernetic-org/git-workflow-agent-skill/compare/v1.0.4...v1.1.0
 [1.0.4]: https://github.com/qubernetic-org/git-workflow-agent-skill/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/qubernetic-org/git-workflow-agent-skill/compare/v1.0.2...v1.0.3

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,12 +2,87 @@
 
 Thank you for your interest in improving the git workflow skill.
 
-## How to Contribute
+## Prerequisites
 
-1. **Open an issue first** — describe what you want to change and why.
-2. **Fork the repo** and create a feature branch from `main`.
-3. **Make your changes** following the guidelines below.
-4. **Open a pull request** against `main`.
+- **Git** (2.20+)
+- **Bash** — required for `scripts/lint.sh` (see [Running the Linter](#running-the-linter) for platform-specific instructions)
+- **Claude Code** — for manual testing of skill behavior
+- **GitHub CLI (`gh`)** — optional but recommended for issue/PR management
+
+## Development Workflow
+
+This repo follows its own Gitflow workflow. Every contribution goes through these steps:
+
+```
+1. Open a GitHub Issue describing the change
+2. Fork the repo (external contributors) or create a branch directly (maintainers)
+3. Create a branch from develop:
+   git checkout develop
+   git pull origin develop
+   git checkout -b <type>/<issue>-<slug>
+4. Make atomic commits using Conventional Commits format
+5. Run the linter:
+   ./scripts/lint.sh
+6. Push and open a PR targeting develop:
+   git push -u origin <type>/<issue>-<slug>
+   gh pr create --base develop
+7. Verify test plan items and check them off in the PR description
+8. After merge, clean up:
+   git checkout develop && git pull origin develop
+   git fetch --prune && git branch -d <type>/<issue>-<slug>
+```
+
+### Branch Types
+
+| Change type | Branch prefix | Example |
+|-------------|---------------|---------|
+| New feature | `feature/` | `feature/42-add-search` |
+| Bug fix | `fix/` | `fix/17-broken-navbar` |
+| Documentation | `docs/` | `docs/23-update-readme` |
+
+### Commit Format
+
+```
+<type>(<optional scope>): <description>
+```
+
+Use imperative mood, lowercase after colon, no period. See SKILL.md for the full type reference.
+
+## Running the Linter
+
+The linter (`scripts/lint.sh`) validates SKILL.md structure and version consistency. It requires bash.
+
+### macOS / Linux
+
+```bash
+./scripts/lint.sh
+```
+
+### Windows — Git Bash
+
+Git for Windows includes Git Bash, which can run the linter natively:
+
+```bash
+# Open Git Bash (installed with Git for Windows)
+./scripts/lint.sh
+```
+
+### Windows — WSL
+
+```bash
+# From a WSL terminal
+./scripts/lint.sh
+```
+
+### Windows — PowerShell (via Git Bash)
+
+If you prefer to stay in PowerShell, invoke Git Bash explicitly:
+
+```powershell
+& "C:\Program Files\Git\bin\bash.exe" -c "./scripts/lint.sh"
+```
+
+> **Note:** The linter has zero external dependencies — it only needs bash, grep, awk, and sed, all of which are included in Git Bash and WSL.
 
 ## Guidelines
 
@@ -31,11 +106,12 @@ Every change must preserve these rules in the skill:
 
 ### Testing
 
-Before submitting a PR, test your changes by:
+Before submitting a PR:
 
-1. Copying the updated `SKILL.md` to `~/.claude/skills/git-workflow/SKILL.md`
-2. Starting a new Claude Code session
-3. Asking Claude to perform git operations and verifying it follows the workflow
+1. Run the linter: `./scripts/lint.sh`
+2. Copy the updated `SKILL.md` to `~/.claude/skills/git-workflow/SKILL.md`
+3. Start a new Claude Code session
+4. Ask Claude to perform git operations and verify it follows the workflow
 
 ## Reporting Bugs
 

--- a/ONBOARDING.md
+++ b/ONBOARDING.md
@@ -1,0 +1,81 @@
+# Onboarding
+
+Welcome! This guide helps new contributors understand the project, its structure, and how to work on it effectively.
+
+## What This Project Is
+
+This is a **Claude Code skill** — a single Markdown file (`SKILL.md`) that instructs Claude Code to follow a strict Gitflow-based development workflow. It is not a runnable application, library, or service.
+
+When installed, Claude Code reads SKILL.md and enforces its rules during git operations: creating branches, writing commits, opening PRs, managing releases, and more.
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `SKILL.md` | **The skill itself.** Self-contained installable artifact with YAML frontmatter and the complete workflow specification. This is what users install. |
+| `README.md` | Public-facing documentation with installation instructions and feature overview. |
+| `CHANGELOG.md` | Release history following [Keep a Changelog](https://keepachangelog.com/) format. |
+| `CONTRIBUTING.md` | Contribution rules and invariants. |
+| `CLAUDE.md` | Guidance for Claude Code when working on this repo. |
+| `SECURITY.md` | Vulnerability reporting policy. |
+| `CODE_OF_CONDUCT.md` | Community standards (Contributor Covenant v2.1). |
+| `scripts/lint.sh` | Automated linter that validates SKILL.md structure and version consistency. |
+| `.github/` | PR template, issue templates, and GitHub Actions workflows. |
+
+## How to Install and Test Locally
+
+```bash
+# 1. Copy the skill to Claude Code's skill directory
+mkdir -p ~/.claude/skills/git-workflow
+cp SKILL.md ~/.claude/skills/git-workflow/SKILL.md
+
+# 2. Start a new Claude Code session
+claude
+
+# 3. Test by asking Claude to perform git operations:
+#    - "Create a branch for issue #42"
+#    - "Commit this change"
+#    - "Open a PR"
+#    Verify Claude follows the workflow rules.
+```
+
+## How the Skill Works
+
+1. **Frontmatter** — The YAML block at the top of SKILL.md contains `name`, `description`, and `version`. The `description` field controls when Claude Code activates the skill (keyword matching).
+2. **Rules** — The body defines branch naming, commit format, merge strategy, release process, and forbidden operations.
+3. **Activation** — When a user mentions git-related terms (commit, branch, merge, release, etc.), Claude Code loads the skill and follows its rules.
+
+## Lifecycle of a Change
+
+```
+1. Open a GitHub Issue describing the change
+2. Create a branch from develop: fix/<issue>-<slug> or feature/<issue>-<slug>
+3. Make atomic commits using Conventional Commits format
+4. Run the linter: ./scripts/lint.sh
+5. Push and open a PR targeting develop
+6. Test plan items are verified and checked off in the PR description
+7. PR is merged with --no-ff
+8. Issue is closed (auto-closed by workflow or manually)
+9. Branch is deleted (remote + local)
+```
+
+For releases, the flow is: `develop` → `release/<version>` → `main` (tag + GitHub Release) → back-merge to `develop`.
+
+## Version Sync
+
+Three places must always agree on the version number:
+
+1. `SKILL.md` frontmatter `version` field
+2. `SKILL.md` `metadata.version` field
+3. `README.md` version badge
+4. `CHANGELOG.md` latest entry
+
+Run `./scripts/lint.sh` to verify consistency.
+
+## Common Pitfalls
+
+- **Editing SKILL.md is editing the product** — every change affects how Claude Code behaves for all users of this skill.
+- **SKILL.md must stay self-contained** — don't reference external files from within it. It's copied as a single file.
+- **Version bumps happen on release branches only** — don't bump versions in feature/fix branches.
+- **Always pull before branching** — `git pull origin develop` before `git checkout -b` to avoid stale forks.
+- **No AI co-author signatures** — never add `Co-Authored-By` lines to commits in this repo.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Git Workflow — Claude Code Skill
 
-[![Version](https://img.shields.io/badge/version-1.1.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.2.0-blue.svg)](CHANGELOG.md)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-skill-7c3aed.svg)](https://claude.ai/code)
 [![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196.svg?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)

--- a/SKILL.md
+++ b/SKILL.md
@@ -532,3 +532,74 @@ Follow [Keep a Changelog](https://keepachangelog.com/):
 | Creating a release branch | Bump version on release branch |
 | Merging hotfix to main | Bump PATCH version on hotfix branch |
 | Breaking change anywhere | MAJOR bump at release time |
+
+---
+
+## Troubleshooting
+
+### "I accidentally committed directly to main or develop"
+
+```bash
+# Undo the last commit, keeping changes staged
+git reset --soft HEAD~1
+
+# Create the correct branch and move the changes there
+git checkout -b feature/<issue>-<slug>
+git commit -m "<type>: <description>"
+
+# Reset the protected branch to its remote state
+git checkout main   # or develop
+git reset --hard origin/main   # or origin/develop
+```
+
+### "I forgot to pull before branching and my branch is stale"
+
+```bash
+# If the branch is NOT yet pushed — rebase onto latest base
+git checkout develop && git pull origin develop
+git checkout feature/<issue>-<slug>
+git rebase develop
+
+# If the branch IS already pushed — merge base into your branch
+git checkout feature/<issue>-<slug>
+git merge develop
+```
+
+### "I squash-merged instead of merge-committing"
+
+The atomic commit history is lost. To preserve traceability:
+
+```bash
+# Revert the squash merge
+git revert <squash-merge-commit-hash>
+
+# Re-merge correctly with --no-ff
+git merge --no-ff <branch>
+```
+
+If the branch is already deleted, recreate it from the squash commit, revert, and re-merge.
+
+### "I force-pushed to a shared branch"
+
+```bash
+# Ask collaborators to save their local work
+# Then restore the branch from reflog
+git reflog show <branch>
+git reset --hard <branch>@{N}   # N = the entry before the force-push
+git push --force-with-lease origin <branch>
+```
+
+Coordinate with your team — they may need to `git fetch && git reset --hard origin/<branch>`.
+
+### "I need to cherry-pick a commit to another branch"
+
+```bash
+# Find the commit hash
+git log --oneline <source-branch>
+
+# Apply it to the target branch
+git checkout <target-branch>
+git cherry-pick <commit-hash>
+```
+
+> **Warning:** Cherry-picking duplicates commits. Prefer merging or back-merging when possible. Use cherry-pick only for isolated, urgent fixes.

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: git-workflow
 description: "Enforce a strict Gitflow-based workflow with conventional commits, semantic versioning, and issue-driven branching. Use when the user asks to commit, create a branch, open a PR, tag a release, or perform any git operation. Also applies when mentions 'commit', 'branch', 'merge', 'release', 'hotfix', 'gitflow', 'conventional commit', 'semantic versioning', or 'semver'."
-version: 1.1.0
+version: 1.2.0
 license: MIT
 metadata:
   author: Qubernetic
-  version: 1.1.0
+  version: 1.2.0
 ---
 
 # Git Workflow Skill

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -103,7 +103,7 @@ while IFS= read -r line; do
     heading_ok=false
   fi
   prev_level=$level
-done < <(grep -E '^#{1,6} ' "$SKILL")
+done < <(awk '/^```/{inside=!inside; next} !inside && /^#{1,6} /' "$SKILL")
 
 if $heading_ok; then
   pass "Heading hierarchy is consistent (no skipped levels)"

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+#
+# Lint SKILL.md for structural consistency.
+# Usage: ./scripts/lint.sh [path/to/SKILL.md]
+#
+# Exit codes: 0 = all checks pass, 1 = one or more checks failed
+
+set -euo pipefail
+
+SKILL="${1:-SKILL.md}"
+errors=0
+
+pass() { printf "  \033[32m✓\033[0m %s\n" "$1"; }
+fail() { printf "  \033[31m✗\033[0m %s\n" "$1"; errors=$((errors + 1)); }
+
+echo "Linting $SKILL"
+echo
+
+# --- 1. File exists ---
+if [[ ! -f "$SKILL" ]]; then
+  fail "File not found: $SKILL"
+  exit 1
+fi
+
+# --- 2. YAML frontmatter presence ---
+if head -1 "$SKILL" | grep -q '^---$'; then
+  pass "YAML frontmatter opening delimiter"
+else
+  fail "Missing YAML frontmatter opening '---'"
+fi
+
+frontmatter_end=$(awk 'NR>1 && /^---$/ { print NR; exit }' "$SKILL")
+if [[ -n "$frontmatter_end" ]]; then
+  pass "YAML frontmatter closing delimiter (line $frontmatter_end)"
+else
+  fail "Missing YAML frontmatter closing '---'"
+fi
+
+# --- 3. Required frontmatter fields ---
+frontmatter=$(sed -n "2,$((frontmatter_end - 1))p" "$SKILL")
+
+for field in name description version license; do
+  if echo "$frontmatter" | grep -qE "^${field}:"; then
+    pass "Frontmatter field: $field"
+  else
+    fail "Missing frontmatter field: $field"
+  fi
+done
+
+if echo "$frontmatter" | grep -qE "^  version:"; then
+  pass "Frontmatter field: metadata.version"
+else
+  fail "Missing frontmatter field: metadata.version"
+fi
+
+# --- 4. Version consistency ---
+top_version=$(echo "$frontmatter" | grep -E '^version:' | head -1 | awk '{print $2}')
+meta_version=$(echo "$frontmatter" | grep -E '^  version:' | head -1 | awk '{print $2}')
+
+if [[ "$top_version" == "$meta_version" ]]; then
+  pass "Version consistency: frontmatter ($top_version) = metadata ($meta_version)"
+else
+  fail "Version mismatch: frontmatter ($top_version) != metadata ($meta_version)"
+fi
+
+# --- 5. README badge version (if README exists) ---
+if [[ -f "README.md" ]]; then
+  badge_version=$(grep -oP 'version-\K[0-9]+\.[0-9]+\.[0-9]+' README.md | head -1)
+  if [[ "$badge_version" == "$top_version" ]]; then
+    pass "README badge version ($badge_version) matches SKILL.md ($top_version)"
+  else
+    fail "README badge version ($badge_version) != SKILL.md ($top_version)"
+  fi
+fi
+
+# --- 6. CHANGELOG version (if CHANGELOG exists) ---
+if [[ -f "CHANGELOG.md" ]]; then
+  changelog_version=$(grep -oP '## \[\K[0-9]+\.[0-9]+\.[0-9]+' CHANGELOG.md | head -1)
+  if [[ "$changelog_version" == "$top_version" ]]; then
+    pass "CHANGELOG latest version ($changelog_version) matches SKILL.md ($top_version)"
+  else
+    fail "CHANGELOG latest version ($changelog_version) != SKILL.md ($top_version)"
+  fi
+fi
+
+# --- 7. Trailing whitespace ---
+trailing=$(grep -nE ' +$' "$SKILL" | head -5 || true)
+if [[ -z "$trailing" ]]; then
+  pass "No trailing whitespace"
+else
+  fail "Trailing whitespace found:"
+  echo "$trailing" | sed 's/^/        /'
+fi
+
+# --- 8. Section heading hierarchy (no skipped levels) ---
+prev_level=0
+heading_ok=true
+while IFS= read -r line; do
+  level=$(echo "$line" | grep -oE '^#{1,6}' | wc -c)
+  level=$((level - 1))
+  if [[ $prev_level -gt 0 && $level -gt $((prev_level + 1)) ]]; then
+    fail "Heading level skipped: '$line' (h$level after h$prev_level)"
+    heading_ok=false
+  fi
+  prev_level=$level
+done < <(grep -E '^#{1,6} ' "$SKILL")
+
+if $heading_ok; then
+  pass "Heading hierarchy is consistent (no skipped levels)"
+fi
+
+# --- Summary ---
+echo
+if [[ $errors -eq 0 ]]; then
+  printf "\033[32mAll checks passed.\033[0m\n"
+else
+  printf "\033[31m%d check(s) failed.\033[0m\n" "$errors"
+fi
+
+exit $((errors > 0 ? 1 : 0))


### PR DESCRIPTION
## Summary
- Bump version to 1.2.0 in SKILL.md (frontmatter + metadata), README.md badge, and CHANGELOG.md
- CHANGELOG includes all changes since v1.1.0

Closes #65

## Test plan
- [x] SKILL.md frontmatter and metadata version are 1.2.0
- [x] README.md badge shows 1.2.0
- [x] CHANGELOG.md has [1.2.0] section with correct entries and comparison link
- [x] `./scripts/lint.sh` passes all checks