### PR TITLE
docs: update README installation section with platform-specific scripts (#74)

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,11 +19,56 @@ A Claude Code skill that enforces a disciplined Gitflow-based development workfl
 
 ## Installation
 
-Copy the `SKILL.md` file to your global Claude Code skills directory:
+Clone the repo and run the install script for your platform. The script creates a **symlink**, so the skill stays in sync with the repo automatically.
+
+### Linux
+
+```bash
+git clone https://github.com/qubernetic-org/git-workflow-agent-skill.git
+cd git-workflow-agent-skill
+./scripts/install_linux.sh
+```
+
+### macOS
+
+```bash
+git clone https://github.com/qubernetic-org/git-workflow-agent-skill.git
+cd git-workflow-agent-skill
+./scripts/install_macos.sh
+```
+
+### Windows (PowerShell)
+
+```powershell
+git clone https://github.com/qubernetic-org/git-workflow-agent-skill.git
+cd git-workflow-agent-skill
+.\scripts\install_windows.ps1
+```
+
+> **Note:** Windows symlinks require Developer Mode enabled or an elevated terminal. The script falls back to a file copy if symlinks are unavailable.
+
+### Uninstall
+
+```bash
+# Linux
+./scripts/install_linux.sh --uninstall
+
+# macOS
+./scripts/install_macos.sh --uninstall
+```
+
+```powershell
+# Windows
+.\scripts\install_windows.ps1 -Uninstall
+```
+
+### Manual Installation
+
+If you prefer not to use the scripts:
 
 ```bash
 mkdir -p ~/.claude/skills/git-workflow
-cp SKILL.md ~/.claude/skills/git-workflow/SKILL.md
+ln -s "$(pwd)/SKILL.md" ~/.claude/skills/git-workflow/SKILL.md
 ```
 
 The skill will be automatically discovered on the next Claude Code session.


### PR DESCRIPTION
## Summary
- Replace manual `mkdir + cp` with clone + install script for Linux, macOS, and Windows
- Add uninstall instructions for all platforms
- Keep manual symlink method as fallback
- Explain symlink advantage (auto-sync with repo)

Closes #74

## Test plan
- [x] Linux install instructions reference `install_linux.sh`
- [x] macOS install instructions reference `install_macos.sh`
- [x] Windows install instructions reference `install_windows.ps1`
- [x] Uninstall section covers all 3 platforms
- [x] Manual fallback uses symlink (not cp)