### PR TITLE
feat(ci): add GitHub Actions workflow to run lint on PRs (#79)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint SKILL.md
+
+on:
+  pull_request:
+    branches: [main, develop]
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Run lint
+        run: ./scripts/lint.sh


### PR DESCRIPTION
## Summary
- Add `.github/workflows/lint.yml` — runs `scripts/lint.sh` on every PR targeting `main` or `develop`
- Lightweight: uses only `actions/checkout@v4`, no extra dependencies

Closes #79

## Test plan
- [x] Workflow triggers on this PR (targeting develop)
- [x] Lint check passes (green checkmark on PR)