### PR TITLE
fix: add GitHub Actions lint status badge to README (#92)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 # Git Workflow — Claude Code Skill
 
+[![Lint](https://github.com/qubernetic-org/git-workflow-agent-skill/actions/workflows/lint.yml/badge.svg)](https://github.com/qubernetic-org/git-workflow-agent-skill/actions/workflows/lint.yml)
 [![Version](https://img.shields.io/badge/version-1.3.0-blue.svg)](CHANGELOG.md)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-skill-7c3aed.svg)](https://claude.ai/code)


### PR DESCRIPTION
## Summary
- Add lint workflow status badge to README badge row

Closes #92

## Test plan
- [x] Badge renders on GitHub (check PR diff preview)
- [x] Badge links to Actions workflow page
- [x] Lint CI passes