### PR TITLE
chore: back-merge v1.4.0 into develop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.4.0] - 2026-03-28
+
+### Added
+
+- GitHub Actions workflow to run lint on every PR (#79)
+- Lint status badge in README (#92)
+- Workflow comparison section in README: Gitflow vs GitHub Flow vs Trunk-Based (#80)
+- Integration guide with commitlint, husky, and branch name CI validation (#91)
+- 5 additional troubleshooting scenarios: wrong base branch, merge conflicts, deleted branch, committed secrets, wrong merge target (#81)
+- ONBOARDING.md worked example and FAQ section (#82)
+- ONBOARDING.md link in README navigation bar (#87)
+
+### Changed
+
+- Upgrade GitHub Actions to Node.js 24: checkout v4→v5, github-script v7→v8 (#80)
+- Update CLAUDE.md Architecture section to include scripts/ and workflows (#89)
+- Update CLAUDE.md Testing section with lint and install script references (#89)
+
 ## [1.3.0] - 2026-03-27
 
 ### Added
@@ -107,6 +125,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CONTRIBUTING.md contribution guidelines
 - GitHub issue and PR templates
 
+[1.4.0]: https://github.com/qubernetic-org/git-workflow-agent-skill/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/qubernetic-org/git-workflow-agent-skill/compare/v1.2.0...v1.3.0
 [1.2.0]: https://github.com/qubernetic-org/git-workflow-agent-skill/compare/v1.1.0...v1.2.0
 [1.1.0]: https://github.com/qubernetic-org/git-workflow-agent-skill/compare/v1.0.4...v1.1.0

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # Git Workflow — Claude Code Skill
 
 [![Lint](https://github.com/qubernetic-org/git-workflow-agent-skill/actions/workflows/lint.yml/badge.svg)](https://github.com/qubernetic-org/git-workflow-agent-skill/actions/workflows/lint.yml)
-[![Version](https://img.shields.io/badge/version-1.3.0-blue.svg)](CHANGELOG.md)
+[![Version](https://img.shields.io/badge/version-1.4.0-blue.svg)](CHANGELOG.md)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![Claude Code](https://img.shields.io/badge/Claude%20Code-skill-7c3aed.svg)](https://claude.ai/code)
 [![Conventional Commits](https://img.shields.io/badge/commits-conventional-fe5196.svg?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: git-workflow
 description: "Enforce a strict Gitflow-based workflow with conventional commits, semantic versioning, and issue-driven branching. Use when the user asks to commit, create a branch, open a PR, tag a release, or perform any git operation. Also applies when mentions 'commit', 'branch', 'merge', 'release', 'hotfix', 'gitflow', 'conventional commit', 'semantic versioning', or 'semver'."
-version: 1.3.0
+version: 1.4.0
 license: MIT
 metadata:
   author: Qubernetic
-  version: 1.3.0
+  version: 1.4.0
 ---
 
 # Git Workflow Skill


### PR DESCRIPTION
Back-merge main into develop after v1.4.0 release. No code review required — content already reviewed for main.